### PR TITLE
Make network firewall optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The hardening mechanism Codex uses depends on your OS:
   custom `iptables`/`ipset` firewall script denies all egress except the
   OpenAI API. This gives you deterministic, reproducible runs without needing
   root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+  Pass `--allow-network` to skip the firewall if you want unrestricted egress.
 
 ---
 

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -13,6 +13,10 @@ WORK_DIR="${WORKSPACE_ROOT_DIR:-$(pwd)}"
 # Default allowed domains - can be overridden with OPENAI_ALLOWED_DOMAINS env var
 OPENAI_ALLOWED_DOMAINS="${OPENAI_ALLOWED_DOMAINS:-api.openai.com}"
 
+# Whether to allow outbound network. When enabled, the container will start
+# without the restrictive firewall rules.
+ALLOW_NETWORK=false
+
 # Parse optional flag.
 if [ "$1" = "--work_dir" ]; then
   if [ -z "$2" ]; then
@@ -21,6 +25,11 @@ if [ "$1" = "--work_dir" ]; then
   fi
   WORK_DIR="$2"
   shift 2
+fi
+
+if [ "$1" = "--allow-network" ]; then
+  ALLOW_NETWORK=true
+  shift
 fi
 
 WORK_DIR=$(realpath "$WORK_DIR")
@@ -47,8 +56,8 @@ if [ -z "$WORK_DIR" ]; then
   exit 1
 fi
 
-# Verify that OPENAI_ALLOWED_DOMAINS is not empty
-if [ -z "$OPENAI_ALLOWED_DOMAINS" ]; then
+# Verify that OPENAI_ALLOWED_DOMAINS is not empty when firewall is enabled
+if ! $ALLOW_NETWORK && [ -z "$OPENAI_ALLOWED_DOMAINS" ]; then
   echo "Error: OPENAI_ALLOWED_DOMAINS is empty."
   exit 1
 fi
@@ -66,24 +75,26 @@ docker run --name "$CONTAINER_NAME" -d \
   sleep infinity
 
 # Write the allowed domains to a file in the container
-docker exec --user root "$CONTAINER_NAME" bash -c "mkdir -p /etc/codex"
-for domain in $OPENAI_ALLOWED_DOMAINS; do
-  # Validate domain format to prevent injection
-  if [[ ! "$domain" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
-    echo "Error: Invalid domain format: $domain"
-    exit 1
-  fi
-  echo "$domain" | docker exec --user root -i "$CONTAINER_NAME" bash -c "cat >> /etc/codex/allowed_domains.txt"
-done
+if ! $ALLOW_NETWORK; then
+  docker exec --user root "$CONTAINER_NAME" bash -c "mkdir -p /etc/codex"
+  for domain in $OPENAI_ALLOWED_DOMAINS; do
+    # Validate domain format to prevent injection
+    if [[ ! "$domain" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+      echo "Error: Invalid domain format: $domain"
+      exit 1
+    fi
+    echo "$domain" | docker exec --user root -i "$CONTAINER_NAME" bash -c "cat >> /etc/codex/allowed_domains.txt"
+  done
 
-# Set proper permissions on the domains file
-docker exec --user root "$CONTAINER_NAME" bash -c "chmod 444 /etc/codex/allowed_domains.txt && chown root:root /etc/codex/allowed_domains.txt"
+  # Set proper permissions on the domains file
+  docker exec --user root "$CONTAINER_NAME" bash -c "chmod 444 /etc/codex/allowed_domains.txt && chown root:root /etc/codex/allowed_domains.txt"
 
-# Initialize the firewall inside the container as root user
-docker exec --user root "$CONTAINER_NAME" bash -c "/usr/local/bin/init_firewall.sh"
+  # Initialize the firewall inside the container as root user
+  docker exec --user root "$CONTAINER_NAME" bash -c "/usr/local/bin/init_firewall.sh"
 
-# Remove the firewall script after running it
-docker exec --user root "$CONTAINER_NAME" bash -c "rm -f /usr/local/bin/init_firewall.sh"
+  # Remove the firewall script after running it
+  docker exec --user root "$CONTAINER_NAME" bash -c "rm -f /usr/local/bin/init_firewall.sh"
+fi
 
 # Execute the provided command in the container, ensuring it runs in the work directory.
 # We use a parameterized bash command to safely handle the command and directory.

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -172,6 +172,7 @@ impl SandboxPolicy {
                 SandboxPermission::DiskFullReadAccess,
                 SandboxPermission::DiskWritePlatformUserTempFolder,
                 SandboxPermission::DiskWriteCwd,
+                SandboxPermission::NetworkFullAccess,
             ],
         }
     }


### PR DESCRIPTION
## Summary
- document `--allow-network` option
- add optional network support to container script
- allow network in full auto policy

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6840aa4fad84832eb08729e206a3c6c6